### PR TITLE
Update build.yml to use the latest ubuntu latest as ubunut 18 is deprecated + skip semantic release for now

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -11,8 +11,8 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: [3.7, 3.8, 3.9]
-        os: [ubuntu-18.04]
+        python-version: [3.9]
+        os: [ubuntu-latest]
 
     steps:
     - name: Checkout
@@ -28,7 +28,7 @@ jobs:
         pip install -r requirements.txt
         pip install -r requirements_dev.txt
     - name: Run tests
-      run: tox
+      run: tox -vv
 
   release:
     name: Release
@@ -39,25 +39,21 @@ jobs:
         uses: actions/checkout@v2
         with:
           fetch-depth: 0
-
-      - name: Setup Node.js
-        uses: actions/setup-node@v2
+      - name: Set up Python
+        uses: actions/setup-python@v1
         with:
-          node-version: '16'
-
-      - name: Setup
-        run: npm install -g semantic-release @semantic-release/github @semantic-release/changelog @semantic-release/commit-analyzer @semantic-release/git @semantic-release/release-notes-generator semantic-release-pypi
-
-      - name: Set up python
-        uses: actions/setup-python@v2
-        with:
-          python-version: 3.8
-
-      - name: Install setuptools
-        run: python -m pip install --upgrade setuptools wheel twine
-
-      - name: Release
+          python-version: '3.x'
+      - name: Install twine
+        run: |
+          pip install twine
+          pip install wheel
+          pip install setuptools
+      - name: Upload wheel
+        if: ${{ github.ref == 'refs/heads/main' }}
         env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          PYPI_TOKEN: ${{ secrets.PYPI_TOKEN }}
-        run: npx semantic-release
+          TWINE_USERNAME: __token__
+          TWINE_PASSWORD: ${{ secrets.PYPI_TOKEN }}
+          TWINE_NON_INTERACTIVE: 1
+        run: |
+          python setup.py bdist_wheel
+          twine upload dist/*.whl

--- a/setup.cfg
+++ b/setup.cfg
@@ -2,6 +2,6 @@
 universal = 1
 
 [metadata]
-description-file = README.md
-version = 1.0.1
+description_file = README.md
+version = 1.0.2
 


### PR DESCRIPTION
Update build.yml to use the latest ubuntu latest as ubuntu 18 is deprecated + skip semantic release for now as it needs more configs